### PR TITLE
New User Data Directory

### DIFF
--- a/repository/Chrome-Core.package/GoogleChrome.class/README.md
+++ b/repository/Chrome-Core.package/GoogleChrome.class/README.md
@@ -1,1 +1,5 @@
 Google Chrome
+
+Instance Variables
+
+	userDataDir	<FileReference or nil> The directory used by Chrome to store user data.  It also can be used to force Chrome to start a new session.

--- a/repository/Chrome-Core.package/GoogleChrome.class/instance/debugSession.st
+++ b/repository/Chrome-Core.package/GoogleChrome.class/instance/debugSession.st
@@ -1,0 +1,10 @@
+operating
+debugSession
+	"Set the Chrome user directory to our default to ensure that we are running our instance of Chrome.
+	This is typically done if you are running chrome without the remote debugging port enabled, and don't want to close the browser"
+
+	| debugDataDir |
+	
+	debugDataDir := FileLocator temp / 'pharo' / 'GoogleChrome' / 'debugSession'.
+	debugDataDir ensureCreateDirectory.
+	self userDataDir: debugDataDir.

--- a/repository/Chrome-Core.package/GoogleChrome.class/instance/openURL..st
+++ b/repository/Chrome-Core.package/GoogleChrome.class/instance/openURL..st
@@ -1,7 +1,31 @@
 private - operating
 openURL: anURL
-	|args|
-	args := self isInDebugMode 
-					ifFalse: [ '-- ', anURL ]
-					ifTrue: [ '--remote-debugging-port=',debugPort asString,' ',anURL ].
-	ChromePlatform current openChromeWith: args
+	| args retryCount version |
+	args := String streamContents: [ :stream |
+		userDataDir ifNotNil: [ 
+			stream
+				<< ' --user-data-dir=';
+				<< userDataDir fullName ].
+		self isInDebugMode 
+			ifFalse: [ stream
+							<< ' -- ';
+							<< anURL ]
+			ifTrue: [ stream
+							<< ' --remote-debugging-port=';
+							<< debugPort asString;
+							<< ' ';
+							<< anURL ] ].
+	ChromePlatform current openChromeWith: args.
+	"It can take a while for the browser to actually start.
+	Ping the browser until we get a successfull response."
+	retryCount := 10.
+	[ version := self version ]
+		on: ConnectionTimedOut
+		do: [ :ex |
+			retryCount > 0 ifTrue:
+				[ retryCount := retryCount - 1.
+				1 second wait.
+				ex retry. ]
+			ifFalse:
+				[ ex pass ]
+			].

--- a/repository/Chrome-Core.package/GoogleChrome.class/instance/userDataDir..st
+++ b/repository/Chrome-Core.package/GoogleChrome.class/instance/userDataDir..st
@@ -1,0 +1,5 @@
+accessing
+userDataDir: anObject
+	"Set Chrome's user data directory to the supplied directory (which must already exist).
+	nil = Chrome's default directory (current user's directory)"
+	userDataDir := anObject

--- a/repository/Chrome-Core.package/GoogleChrome.class/instance/userDataDir.st
+++ b/repository/Chrome-Core.package/GoogleChrome.class/instance/userDataDir.st
@@ -1,0 +1,3 @@
+accessing
+userDataDir
+	^ userDataDir

--- a/repository/Chrome-Core.package/GoogleChrome.class/properties.json
+++ b/repository/Chrome-Core.package/GoogleChrome.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "TorstenBergmann 5/18/2017 00:00",
+	"commentStamp" : "AlistairGrant 5/20/2017 09:55",
 	"super" : "Object",
 	"category" : "Chrome-Core-Base",
 	"classinstvars" : [ ],
@@ -8,7 +8,8 @@
 	"instvars" : [
 		"debugPort",
 		"isInDebugMode",
-		"host"
+		"host",
+		"userDataDir"
 	],
 	"name" : "GoogleChrome",
 	"type" : "normal"

--- a/repository/Chrome-Core.package/UnixChromePlatform.class/class/defaultExecutableLocation.st
+++ b/repository/Chrome-Core.package/UnixChromePlatform.class/class/defaultExecutableLocation.st
@@ -1,4 +1,5 @@
 defaults
 defaultExecutableLocation
 
-	^'/usr/bin/chromium-browser'
+	^#('/opt/google/chrome/chrome' '/usr/bin/chromium-browser') detect:
+		[ :each | each asFileReference exists ].


### PR DESCRIPTION
Start Chrome with a new user data directory.

This is typically done if you are running chrome without the remote debugging port enabled, and don't want to close the browser"

E.g.:

| chrome page |

chrome := GoogleChrome new
	debugOn;
	debugSession;
	open;
	yourself.
page := chrome tabPages first.
page navigateTo: 'http://www.pharo.org'.
(Delay forSeconds: 5) wait.
{ chrome version. page captureScreenshot scaledToSize: 800@600. }