### PR TITLE
Simple updates and fixes.

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : 'repository'
+}

--- a/repository/.properties
+++ b/repository/.properties
@@ -1,0 +1,3 @@
+{
+	#format : #filetree
+}

--- a/repository/BaselineOfChrome.package/BaselineOfChrome.class/instance/baseline..st
+++ b/repository/BaselineOfChrome.package/BaselineOfChrome.class/instance/baseline..st
@@ -4,17 +4,13 @@ baseline: spec
 
 	spec for: #'common' do: [
 		spec blessing: #'baseline'.
-		spec project: 'ZincHTTPComponents' with: [
+		spec baseline: 'ZincHTTPComponents' with: [
 				spec
-					className: #ConfigurationOfZincHTTPComponents;
-					versionString: #'stable';
-					loads: #('WebSocket');
-					repository: 'http://mc.stfx.eu/ZincHTTPComponents' ].
-		spec project: 'Beacon' with: [ 
+					loads: 'WebSocket';
+					repository: 'github://svenvc/ZincHTTPComponents' ].
+		spec baseline: 'Beacon' with: [ 
 			spec
-				className: #ConfigurationOfBeacon;
-				versionString: #development;
-				repository: 'http://smalltalkhub.com/mc/girba/Beacon/main/' ].
+				repository: 'github://pharo-project/pharo-beacon' ].
 		spec baseline: 'AKGOSProcess' with: [ 
 			spec
 				repository: 'github://akgrant43/pharo-akgosprocess/mc' ].

--- a/repository/BaselineOfChrome.package/BaselineOfChrome.class/instance/baseline..st
+++ b/repository/BaselineOfChrome.package/BaselineOfChrome.class/instance/baseline..st
@@ -7,7 +7,7 @@ baseline: spec
 		spec baseline: 'ZincHTTPComponents' with: [
 				spec
 					loads: 'WebSocket';
-					repository: 'github://svenvc/ZincHTTPComponents' ].
+					repository: 'github://svenvc/zinc' ].
 		spec baseline: 'Beacon' with: [ 
 			spec
 				repository: 'github://pharo-project/pharo-beacon' ].

--- a/repository/Chrome-Core.package/ChromeFrameLoadingProcessor.class/instance/ensureIdleTimer.st
+++ b/repository/Chrome-Core.package/ChromeFrameLoadingProcessor.class/instance/ensureIdleTimer.st
@@ -8,7 +8,7 @@ ensureIdleTimer
 	idleProcess := [ | done timeDiff frameLoaded |
 		ChromeIdleTimerSignal new
 			message: 'Started idle timer';
-			log.
+			emit.
 		done := false.
 		[ done ] whileFalse:
 			[ (Delay forMilliseconds: 500) wait.
@@ -17,22 +17,22 @@ ensureIdleTimer
 				message: 'Checking';
 				loadedTimestamp: loadedTimestamp;
 				frameLoaded: frameLoaded;
-				log.
+				emit.
 			(loadedTimestamp isNotNil and: [ frameLoaded ]) ifTrue: [
 				timeDiff := (DateAndTime now - loadedTimestamp) asMilliSeconds.
 				ChromeIdleTimerSignal new 
 					message: 'timeDiff';
 					timeDiff: timeDiff;
-					log.
+					emit.
 		 		timeDiff >= pageLoadDelay ifTrue:
 					[ done := true.
 					ChromeIdleTimerSignal new
 						message: 'Signalling';
-						log.
+						emit.
 					semaphore signal. ]
 				]
 			].
 		ChromeIdleTimerSignal new 
 			message: 'Idle Timer Done';
-			log.
+			emit.
 		] forkNamed: 'Chrome Idle Timer'

--- a/repository/Chrome-Core.package/ChromeStringSignal.class/class/log.category..st
+++ b/repository/Chrome-Core.package/ChromeStringSignal.class/class/log.category..st
@@ -3,4 +3,4 @@ log: aString category: aCategory
 	^ self new 
 		message: aString;
 		category: aCategory;
-		log
+		emit

--- a/repository/Chrome-Core.package/ChromeTabPage.class/instance/captureScreenshot.st
+++ b/repository/Chrome-Core.package/ChromeTabPage.class/instance/captureScreenshot.st
@@ -15,4 +15,4 @@ captureScreenshot
       } asDictionary.
 	base64 := (json at: 'result') at: 'data'.
 	
-	^Form fromBinaryStream: (Base64MimeConverter mimeDecodeToBytes: base64 readStream) 
+	^Form fromBinaryStream: base64 base64Decoded readStream

--- a/repository/Chrome-Core.package/GoogleChrome.class/instance/closeAndExit.st
+++ b/repository/Chrome-Core.package/GoogleChrome.class/instance/closeAndExit.st
@@ -2,4 +2,4 @@ operating
 closeAndExit
 	"Ask the browser to exit"
 
-	chromeProcess sigterm.
+	chromeProcess ifNotNil: [ chromeProcess sigterm ].

--- a/repository/Chrome-Tests-Core.package/GoogleChromeTestResource.class/instance/tearDown.st
+++ b/repository/Chrome-Tests-Core.package/GoogleChromeTestResource.class/instance/tearDown.st
@@ -4,7 +4,8 @@ tearDown
 	| osProcess |
 
 	page1html delete.
-	osProcess := browser chromeProcess process.
+	(browser chromeProcess) ifNotNil: [ osProcess := browser chromeProcess process ].
 	browser closeAndExit.
-	[ osProcess isComplete ] whileFalse:
-		[ (Delay forMilliseconds: 200) wait ].
+	osProcess ifNotNil: [
+		[ osProcess isComplete ] whileFalse:
+			[ (Delay forMilliseconds: 200) wait ]].


### PR DESCRIPTION
Hi Torsten,

This PR has following changes:
- Fix the baseline to load Zinc WebSocket and Beacon from Github.
- Change Beacon #log to #emit.
- Use #base64Decoded in place of deprecated message.
- Test that 'browser chromeProcess' isn't nil before sending it messages.

All tests pass on macOS Mojave with Chrome, and Ubuntu 18.04 with Chromium, both running 64-bit Pharo 7.0 pre-release images.

Cheers.

- Pierce